### PR TITLE
Update affiliation of Akira Matsui in program-committee.csv

### DIFF
--- a/_data/program-committee.csv
+++ b/_data/program-committee.csv
@@ -1,7 +1,7 @@
 name,picture,site,institution
 浅谷 公威,/assets/images/committee/kimitaka_asatani.jpg,https://researchmap.jp/kimitaka_asatani,東京大学
 吉田 光男,/assets/images/committee/mitsuo_yoshida.jpg,https://www.gssm.otsuka.tsukuba.ac.jp/~mitsuo/,筑波大学
-松井 暉,/assets/images/committee/akira_matsui.jpeg,https://er-web.ynu.ac.jp/html/MATSUI_Akira/ja.html,横浜国立大学
+松井 暉,/assets/images/committee/akira_matsui.jpeg,https://www.rieb.kobe-u.ac.jp/faculty/global_finance/a_matsui.html,神戸大学
 三浦 千哲,/assets/images/committee/chiaki_miura.jpg,https://twitter.com/muler314,東京大学
 持橋 大地,/assets/images/committee/avator_placeholder_8.jpg,,
 佐野 幸恵,/assets/images/committee/avator_placeholder_6.jpg,,


### PR DESCRIPTION
This pull request updates the affiliation of 松井 暉 (Akira Matsui) in the `program-committee.csv` file.

**Before:**
横浜国立大学 (Yokohama National University)

**After:**
神戸大学 (Kobe University)

This change reflects the author's current institutional affiliation.
